### PR TITLE
Notice should include also Maven Plug-ins and their licenses

### DIFF
--- a/notices.txt
+++ b/notices.txt
@@ -19,6 +19,9 @@ In the following sections you can find
 
 This project contains software from the following providers:
 * Eclipse Foundation (https://www.eclipse.org/)
+* Mycila
+* Association for the promotion of open-source insurance software and for the establishment of open interface standards in the insurance industry
+* Marko Wallin
 
 
 ====================================================================
@@ -67,6 +70,9 @@ Apache License Version 2.0
 * commons-io.jar
 * commons-lang3.jar
 * javaewah_1.1.6.v20160919-1400.jar
+* license-maven-plugin-3.0.jar
+* licensescout-maven-plugin-1.3.0.jar
+* maven-deploy-plugin-3.0.0-M1.jar
 * org.apache.batik.constants_1.10.0.v20180703-1553.jar
 * org.apache.batik.css_1.10.0.v20180703-1553.jar
 * org.apache.batik.i18n_1.10.0.v20180703-1553.jar
@@ -102,6 +108,7 @@ Eclipse Public License Version 1.0
 * com.jcraft.jsch_0.1.54.v20170116-1932.jar / Eclipse Foundation
 * com.jcraft.jzlib_1.1.1.v201205102305.jar
 * h2.jar
+* jacoco-maven-plugin-0.8.3.jar
 * javaewah_1.1.6.v20160919-1400.jar
 * javax.annotation_1.2.0.v201602091430.jar / Eclipse Foundation
 * javax.inject_1.0.0.v20091030.jar / Eclipse Foundation
@@ -131,6 +138,10 @@ Eclipse Public License Version 1.0
 * org.w3c.dom.events_3.0.0.draft20060413_v201105210656.jar / Eclipse Foundation
 * org.w3c.dom.smil_1.0.1.v200903091627.jar / Eclipse Foundation
 * org.w3c.dom.svg_1.1.0.v201011041433.jar / Eclipse Foundation
+* target-platform-configuration-1.4.0.jar
+* tycho-maven-plugin-1.4.0.jar
+* tycho-p2-director-plugin-1.4.0.jar
+* tycho-p2-repository-plugin-1.4.0.jar
 
 
 Eclipse Public License Version 2.0
@@ -200,6 +211,7 @@ Eclipse Public License Version 2.0
 
 MIT License
 
+* markdown-page-generator-plugin-2.1.0.jar
 * org.apache.felix.gogo.runtime_1.1.0.v20180713-1646.jar
 * org.bouncycastle.bcpg_1.60.0.v20181210-2057.jar
 * org.bouncycastle.bcpkix_1.60.0.v20181210-2057.jar


### PR DESCRIPTION
Added maven plugins and their licenses to notices.txt manually.
As long as licensescout does not support this feature, we do it manually. 