### PR TITLE
Fixed querying for the last log message. Only the last revision is of…

### DIFF
--- a/bundles/org.aposin.mergeprocessor/src/org/aposin/mergeprocessor/model/svn/ISvnClient.java
+++ b/bundles/org.aposin.mergeprocessor/src/org/aposin/mergeprocessor/model/svn/ISvnClient.java
@@ -21,6 +21,7 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 /**
@@ -78,16 +79,21 @@ public interface ISvnClient extends AutoCloseable {
 	List<SvnLog> log(URL url, long fromRevision, long toRevision, String author) throws SvnClientException;
 
 	/**
-	 * Returns a list of logs changed by the given author.
+	 * Returns the log for a given revision.
 	 * 
-	 * @param url          the SVN URL
-	 * @param fromRevision the revision number to start from (inclusivly)
-	 * @param toRevision   the revision number to end to
-	 * @return the log list
+	 * @param url      the SVN URL
+	 * @param revision the revision number
+	 * @return the log entry
 	 * @throws SvnClientException
 	 */
-	default List<SvnLog> log(URL url, long fromRevision, long toRevision) throws SvnClientException {
-		return log(url, fromRevision, toRevision, null);
+	default Optional<SvnLog> log(URL url, long revision) throws SvnClientException {
+		final List<SvnLog> log = log(url, revision, revision, null);
+		if (log.isEmpty()) {
+			return Optional.empty();
+		} else if (log.size() > 1) {
+			throw new SvnClientException("More than 1 log entry is available. This must not happen.");
+		}
+		return Optional.of(log.get(0));
 	}
 
 	/**

--- a/bundles/org.aposin.mergeprocessor/src/org/aposin/mergeprocessor/model/svn/SVNMergeUnitFactory.java
+++ b/bundles/org.aposin.mergeprocessor/src/org/aposin/mergeprocessor/model/svn/SVNMergeUnitFactory.java
@@ -41,6 +41,7 @@ import org.apache.commons.io.IOUtils;
 import org.aposin.mergeprocessor.configuration.IConfiguration;
 import org.aposin.mergeprocessor.model.MergeUnitException;
 import org.aposin.mergeprocessor.model.MergeUnitStatus;
+import org.aposin.mergeprocessor.utils.E4CompatibilityUtil;
 import org.aposin.mergeprocessor.utils.LogUtil;
 
 /**
@@ -148,7 +149,7 @@ public final class SVNMergeUnitFactory {
 				localDate, status, fileData.revisionStart, fileData.revisionEnd, fileData.urlBranchSource,
 				fileData.urlBranchTarget, pathMergeScript, revisionWorkingCopy, neededWorkingCopyFiles.listA,
 				neededWorkingCopyFiles.listB, getTargetFilesToDelete(fileData), getTargetFilesToAdd(fileData),
-				configuration);
+				configuration, E4CompatibilityUtil.getApplicationContext().get(ISvnClient.class));
 
 		// sanity check
 		if (!mergeUnit.isValid()) {

--- a/tests/org.aposin.mergeprocessor.test/src/org/aposin/mergeprocessor/configuration/svn/AbstractSvnClientTest.java
+++ b/tests/org.aposin.mergeprocessor.test/src/org/aposin/mergeprocessor/configuration/svn/AbstractSvnClientTest.java
@@ -31,6 +31,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -115,6 +116,12 @@ public abstract class AbstractSvnClientTest {
 	}
 
 	@Test
+	public void testLogWith2Revisions() throws MalformedURLException, SvnClientException {
+		final List<SvnLog> result = getClient().log(new URL(testRepoUrlString), 1l, 2l, null);
+		assertEquals(2, result.size());
+	}
+
+	@Test
 	public void testLogForUserWithNoEntries() throws MalformedURLException, SvnClientException {
 		final List<SvnLog> result = getClient().log(new URL(testRepoUrlString), 2l, 2l, "bla");
 		assertEquals(0, result.size());
@@ -122,12 +129,12 @@ public abstract class AbstractSvnClientTest {
 
 	@Test
 	public void testLogWithoutUser() throws MalformedURLException, SvnClientException {
-		final List<SvnLog> result = getClient().log(new URL(testRepoUrlString), 2l, 2l);
-		assertEquals(1, result.size());
-		assertEquals(1, result.get(0).getEntries().size());
-		assertEquals(new URL(testRepoUrlString + "/trunk/file2.txt"), result.get(0).getEntries().get(0).getUrl());
-		assertEquals(SvnLogAction.ADDED, result.get(0).getEntries().get(0).getAction());
-		assertEquals("Initial Import file2.txt", result.get(0).getMessage());
+		final Optional<SvnLog> result = getClient().log(new URL(testRepoUrlString), 2l);
+		assertTrue(result.isPresent());
+		assertEquals(1, result.get().getEntries().size());
+		assertEquals(new URL(testRepoUrlString + "/trunk/file2.txt"), result.get().getEntries().get(0).getUrl());
+		assertEquals(SvnLogAction.ADDED, result.get().getEntries().get(0).getAction());
+		assertEquals("Initial Import file2.txt", result.get().getMessage());
 	}
 
 	@Test

--- a/tests/org.aposin.mergeprocessor.test/src/org/aposin/mergeprocessor/configuration/svn/SVNMergeUnitTest.java
+++ b/tests/org.aposin.mergeprocessor.test/src/org/aposin/mergeprocessor/configuration/svn/SVNMergeUnitTest.java
@@ -15,14 +15,22 @@
  */
 package org.aposin.mergeprocessor.configuration.svn;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.aposin.mergeprocessor.model.svn.ISvnClient.SvnDiff;
+import org.aposin.mergeprocessor.model.svn.ISvnClient.SvnLog;
 import org.aposin.mergeprocessor.model.svn.SVNMergeUnit;
+import org.aposin.mergeprocessor.model.svn.SvnClientMock;
 import org.aposin.mergeprocessor.utils.SvnUtilException;
 import org.junit.jupiter.api.Test;
 
@@ -43,10 +51,139 @@ public class SVNMergeUnitTest {
 	@Test
 	public void testConvertSvnDiffToPathUsingSpaces() throws MalformedURLException {
 		final SVNMergeUnit mergeUnit = new SVNMergeUnit(null, null, null, null, 0l, 0l,
-				"https://my.svn.repository.com/branches/V18.0", null, null, 0l, null, null, null, null, null);
+				"https://my.svn.repository.com/branches/V18.0", null, null, 0l, null, null, null, null, null, null);
 		final SvnDiff svnDiff = new SvnDiffMock(
 				new URL("https://my.svn.repository.com/branches/V18.0/file with blanks.txt"));
 		assertEquals(Paths.get("file with blanks.txt"), mergeUnit.convertSvnDiffToPath(svnDiff));
+	}
+
+	/**
+	 * Tests that {@link SVNMergeUnit#getMessage()} creates a valid commit message
+	 * with only 1 source message info from SVN.
+	 */
+	@Test
+	public void testGetMessage() {
+		final SVNMergeUnit mergeUnit = new SVNMergeUnit(null, null, null, null, 1l, 2l,
+				"https://my.svn.repository.com/branches/V18.0", "https://my.svn.repository.com/branches/V19.0", null,
+				0l, null, null, null, null, null, new SvnClientMock() {
+
+					@Override
+					public List<SvnLog> log(URL url, long fromRevision, long toRevision, String author)
+							throws SvnClientException {
+						final long count = toRevision - fromRevision + 1;
+						final List<SvnLog> logs = new ArrayList<>();
+						for (int i = 0; i < count; i++) {
+							logs.add(new SvnLogMock(i, "Message " + i));
+						}
+						return logs;
+					}
+
+				});
+
+		/*
+		 * Message should look like: MP [1:2] V18.0 -> V19.0 r0: [Testauthor]
+		 * (2019-10-07 08:38:47) Message 0
+		 */
+		final String message = mergeUnit.getMessage();
+		assertTrue(message.trim().endsWith("Message 0"));
+		assertFalse(message.contains("Message 1"));
+		assertTrue(message.startsWith("MP [1:2] V18.0 -> V19.0"));
+	}
+
+	/**
+	 * Tests that {@link SVNMergeUnit#getMessage()} does not throw an
+	 * {@link Exception} when no valid branch could be identified.
+	 */
+	@Test
+	public void testGetMessageWhenNoValidBranchCanBeIdentified() {
+		final SVNMergeUnit mergeUnit = new SVNMergeUnit(null, null, null, null, 1l, 2l,
+				"https://my.svn.repository.com/hugo", "https://my.svn.repository.com/franz", null, 0l, null, null, null,
+				null, null, new SvnClientMock() {
+
+					@Override
+					public List<SvnLog> log(URL url, long fromRevision, long toRevision, String author)
+							throws SvnClientException {
+						final long count = toRevision - fromRevision + 1;
+						final List<SvnLog> logs = new ArrayList<>();
+						for (int i = 0; i < count; i++) {
+							logs.add(new SvnLogMock(i, "Message " + i));
+						}
+						return logs;
+					}
+
+				});
+		assertDoesNotThrow(() -> mergeUnit.getMessage());
+	}
+
+	/**
+	 * Tests that {@link SVNMergeUnit#getMessage()} creates a valid commit message
+	 * even if no valid revision numbers are available.
+	 */
+	@Test
+	public void testGetMessageOnIllegalRevisions() {
+		final SVNMergeUnit mergeUnit = new SVNMergeUnit(null, null, null, null, 2l, -1l,
+				"https://my.svn.repository.com/V18.0", "https://my.svn.repository.com/V19.0", null, 0l, null, null,
+				null, null, null, null);
+		/*
+		 * Message should look like: MP [2:-1] UNKNOWN -> UNKNOWN
+		 */
+		final String message = mergeUnit.getMessage();
+		assertFalse(message.contains("Message 0"));
+		assertFalse(message.contains("Message 1"));
+	}
+
+	/**
+	 * Tests that {@link SVNMergeUnit#getMessage()} creates a valid commit message
+	 * even if no logs can be queried via SVN.
+	 */
+	@Test
+	public void testGetMessageWhenNoLogIsIdentified() {
+		final SVNMergeUnit mergeUnit = new SVNMergeUnit(null, null, null, null, 1l, 2l,
+				"https://my.svn.repository.com/branches/V18.0", "https://my.svn.repository.com/branches/V19.0", null,
+				0l, null, null, null, null, null, new SvnClientMock() {
+
+					@Override
+					public List<SvnLog> log(URL url, long fromRevision, long toRevision, String author)
+							throws SvnClientException {
+						return List.of();
+					}
+
+				});
+		/*
+		 * Message should look like: MP [1:2] V18.0 -> V19.0 r0: [Testauthor]
+		 * (2019-10-07 08:38:47) Message 0
+		 */
+		final String message = mergeUnit.getMessage();
+		assertFalse(message.contains("Message 0"));
+		assertFalse(message.contains("Message 1"));
+		assertTrue(message.trim().equals("MP [1:2] V18.0 -> V19.0"));
+	}
+
+	/**
+	 * Tests that {@link SVNMergeUnit#getMessage()} creates a valid commit message
+	 * even if an Exception is thrown by SVN.
+	 */
+	@Test
+	public void testGetMessageWhenLogThrowsException() {
+		final SVNMergeUnit mergeUnit = new SVNMergeUnit(null, null, null, null, 1l, 2l,
+				"https://my.svn.repository.com/branches/V18.0", "https://my.svn.repository.com/branches/V19.0", null,
+				0l, null, null, null, null, null, new SvnClientMock() {
+
+					@Override
+					public List<SvnLog> log(URL url, long fromRevision, long toRevision, String author)
+							throws SvnClientException {
+						throw new SvnClientException("Test Exeption handling");
+					}
+
+				});
+		/*
+		 * Message should look like: MP [1:2] V18.0 -> V19.0 r0: [Testauthor]
+		 * (2019-10-07 08:38:47) Message 0
+		 */
+		final String message = mergeUnit.getMessage();
+		assertFalse(message.contains("Message 0"));
+		assertFalse(message.contains("Message 1"));
+		assertTrue(message.trim().equals("MP [1:2] V18.0 -> V19.0"));
 	}
 
 	/**
@@ -59,6 +196,20 @@ public class SVNMergeUnitTest {
 
 		public SvnDiffMock(final URL url) {
 			super(SvnDiffAction.MODIFIED, url);
+		}
+
+	}
+
+	/**
+	 * Mocked version for instantiation.
+	 * 
+	 * @author Stefan Weiser
+	 *
+	 */
+	private static class SvnLogMock extends SvnLog {
+
+		public SvnLogMock(int revision, final String message) {
+			super(revision, List.of(), message, LocalDateTime.now(), "Testauthor");
 		}
 
 	}

--- a/tests/org.aposin.mergeprocessor.test/src/org/aposin/mergeprocessor/model/svn/SvnClientMock.java
+++ b/tests/org.aposin.mergeprocessor.test/src/org/aposin/mergeprocessor/model/svn/SvnClientMock.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright 2019 Association for the promotion of open-source insurance software and for the establishment of open interface standards in the insurance industry (Verein zur Förderung quelloffener Versicherungssoftware und Etablierung offener Schnittstellenstandards in der Versicherungsbranche)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aposin.mergeprocessor.model.svn;
+
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Svn client implementation mocking the SVN behaviour.
+ * 
+ * @author Stefan Weiser
+ *
+ */
+public class SvnClientMock implements ISvnClient {
+
+	@Override
+	public String cat(URL url) throws SvnClientException {
+		return null;
+	}
+
+	@Override
+	public List<SvnDiff> diff(URL url, long fromRevision, long toRevision) throws SvnClientException {
+		return null;
+	}
+
+	@Override
+	public boolean hasModifications(Path path) throws SvnClientException {
+		return false;
+	}
+
+	@Override
+	public long showRevision(URL url) throws SvnClientException {
+		return 0;
+	}
+
+	@Override
+	public List<SvnLog> log(URL url, long fromRevision, long toRevision, String author) throws SvnClientException {
+		return null;
+	}
+
+	@Override
+	public List<String> listDirectories(URL url) throws SvnClientException {
+		return null;
+	}
+
+	@Override
+	public long[] updateEmpty(List<Path> paths) throws SvnClientException {
+		return null;
+	}
+
+	@Override
+	public void checkoutEmpty(Path path, URL url) throws SvnClientException {
+		//NOOP
+	}
+
+	@Override
+	public void merge(Path path, URL url, long revision, boolean recursivly, boolean recordOnly)
+			throws SvnClientException {
+		//NOOP
+	}
+
+	@Override
+	public void commit(Path path, String message) throws SvnClientException {
+		//NOOP
+	}
+
+	@Override
+	public List<String> getConflicts(Path path) throws SvnClientException {
+		return null;
+	}
+
+	@Override
+	public void update(Path path) throws SvnClientException {
+		//NOOP
+	}
+
+	@Override
+	public URL getSvnUrl(Path path) throws SvnClientException {
+		return null;
+	}
+
+	@Override
+	public URL getRepositoryUrl(Path path) throws SvnClientException {
+		return null;
+	}
+
+	@Override
+	public void addCommandLineListener(Consumer<String> consumer) {
+		//NOOP
+	}
+
+	@Override
+	public void removeCommandLineListener(Consumer<String> consumer) {
+		//NOOP
+	}
+
+	@Override
+	public void close() {
+		//NOOP
+	}
+
+}


### PR DESCRIPTION
Fixes issue #21.

<!--- Provide a general summary of your changes in the Title above -->

<!---  
*DO keep Pull Requests small so they can be easily reviewed.*
 *DO make sure your contribution fits the openness and scalability for future extensions*
 *DO make sure unit tests pass.*
 *DO make sure any public APIs are XML documented.*
 *DO make sure not to introduce any compiler warnings.*
 *AVOID making significant changes to the driver's overall architecture.*
*Delete the above section and the instructions in the sections below before submitting.* 
--->

## Type of request
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Refactoring 
- [ ] Documentation or documentation changes

## Related Issue(s)
<!--- This project only accepts Pull Requests related to open Issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#21 

## Concept 
<!--- Why is this change required? What problem does it solve? -->
Querying for the log of the merged SVN commit requires to change the log call by simply using only 1 revision, e.g. `-r 123:123` (only revision 123 is recognized). Otherwise more than 1 log entry may be found. 
#### Description of the change
<!--- Describe your changes in detail -->
#### Description of current state
#### Description of target state
Log call for commit message looks like e.g. `-r 123:123` (instead of `-r 123:124`)

#### Estimated investment / approximate investment
<!--- Full Time Equivalents / Lines of code / € costs or something like that -->
20 minutes for debugging.

#### Initiator
name / company / position / created at


## Technical information
#### Platform / target area
<!--- What platform(s) is effected? -->

#### known side-effects
#### other 
#### DB Changes (if so: incl. scripts with definitions and testdata)
		


#### How has this Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with manual sample project.
JUnit-Tests adapted.

#### Screenshots, Uploads, other documents (if appropriate):
<!--- describe the uploaded documents -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] All the commits are signed.
- [X][ My code follows the code style of this project.
- [X] I agree with die CLA.
- [X] I have read the CONTRIBUTING docs.
- [ ] I have added/updated necessary documentation (if appropriate).
