### PR TITLE
update IMergeUnit interface

### DIFF
--- a/bundles/org.aposin.mergeprocessor/src/org/aposin/mergeprocessor/model/IMergeUnit.java
+++ b/bundles/org.aposin.mergeprocessor/src/org/aposin/mergeprocessor/model/IMergeUnit.java
@@ -109,6 +109,13 @@ public interface IMergeUnit extends Comparable<IMergeUnit> {
 		return getRenameMapping().entrySet().stream()
 				.anyMatch(entry -> !Objects.equals(entry.getKey(), entry.getValue()));
 	}
+	
+	/**
+	 * Shows the changes of the merge unit.
+	 */
+	default void showChanges() {
+		throw new UnsupportedVersionControlSystemSupportException();
+	}
 
 	/**
 	 * @return the source-target mapping for the involved artifacts of the merge

--- a/bundles/org.aposin.mergeprocessor/src/org/aposin/mergeprocessor/model/git/GITMergeUnit.java
+++ b/bundles/org.aposin.mergeprocessor/src/org/aposin/mergeprocessor/model/git/GITMergeUnit.java
@@ -279,6 +279,14 @@ public final class GITMergeUnit implements IMergeUnit {
 	 * {@inheritDoc}
 	 */
 	@Override
+	public void showChanges() {
+		throw new UnsupportedGITSupportException();
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
 	public Map<Path, Path> getRenameMapping() {
 		throw new UnsupportedOperationException("Renaming not implemented for GIT");
 	}

--- a/bundles/org.aposin.mergeprocessor/src/org/aposin/mergeprocessor/model/svn/SVNMergeUnit.java
+++ b/bundles/org.aposin.mergeprocessor/src/org/aposin/mergeprocessor/model/svn/SVNMergeUnit.java
@@ -567,6 +567,32 @@ public final class SVNMergeUnit implements IMergeUnit, PropertyChangeListener {
 							diff.getUrl(), getUrlSource()));
 		}
 	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void showChanges() {
+		long revisionStart = getRevisionStart();
+		long revisionEnd = getRevisionEnd();
+
+		if (revisionStart > 0 && revisionEnd > 0) {
+			String command = String.format("Tortoiseproc.exe /command:log /path:%s /startrev:%d /endrev:%d", //$NON-NLS-1$
+					getUrlSource(), revisionStart, revisionEnd);
+
+			try {
+				Runtime.getRuntime().exec(command, null, null);
+			} catch (IOException e1) {
+				LOGGER.log(Level.WARNING, "Caught exception while starting Tortoise Log.", e1); //$NON-NLS-1$
+			}
+		} else {
+			if (LOGGER.isLoggable(Level.WARNING)) {
+				LOGGER.log(Level.WARNING, String.format(
+						"Couldn't start Tortoise Log because revisionRange is invalid. revisionStart=%s, revisionEnd=%s", //$NON-NLS-1$
+						revisionStart, revisionEnd));
+			}
+		}
+	}
 
 	/**
 	 * {@inheritDoc}

--- a/bundles/org.aposin.mergeprocessor/src/org/aposin/mergeprocessor/view/mergeunit/MergeScriptDialog.java
+++ b/bundles/org.aposin.mergeprocessor/src/org/aposin/mergeprocessor/view/mergeunit/MergeScriptDialog.java
@@ -142,7 +142,7 @@ public class MergeScriptDialog extends Dialog {
 		} else {
 			view.getTextNeededFiles().setText(sbNeededFiles.toString());
 		}
-		view.getButtonShowChanges().addListener(SWT.Selection, e -> showChanges());
+		view.getButtonShowChanges().addListener(SWT.Selection, e -> mergeUnit.showChanges());
 		view.getTextContent().setText(contentScript);
 		view.getTextContent().setStyleRanges(getStyleRangesForScript(contentScript));
 		view.getButtonClose().addListener(SWT.Selection, e -> shell.close());
@@ -287,51 +287,6 @@ public class MergeScriptDialog extends Dialog {
 			}
 		}
 		return null;
-	}
-
-	/**
-	 * Shows the changes of the merge unit.
-	 */
-	private void showChanges() {
-		if (mergeUnit instanceof SVNMergeUnit) {
-			showSVNChanges((SVNMergeUnit) mergeUnit);
-		} else if (mergeUnit instanceof GITMergeUnit) {
-			showGITChanges((GITMergeUnit) mergeUnit);
-		} else {
-			throw new UnsupportedVersionControlSystemSupportException();
-		}
-	}
-
-	/**
-	 * @param svnMergeUnit the {@link SVNMergeUnit}
-	 */
-	private static void showSVNChanges(final SVNMergeUnit svnMergeUnit) {
-		long revisionStart = svnMergeUnit.getRevisionStart();
-		long revisionEnd = svnMergeUnit.getRevisionEnd();
-
-		if (revisionStart > 0 && revisionEnd > 0) {
-			String command = String.format("Tortoiseproc.exe /command:log /path:%s /startrev:%d /endrev:%d", //$NON-NLS-1$
-					svnMergeUnit.getUrlSource(), revisionStart, revisionEnd);
-
-			try {
-				Runtime.getRuntime().exec(command, null, null);
-			} catch (IOException e1) {
-				LOGGER.log(Level.WARNING, "Caught exception while starting Tortoise Log.", e1); //$NON-NLS-1$
-			}
-		} else {
-			if (LOGGER.isLoggable(Level.WARNING)) {
-				LOGGER.log(Level.WARNING, String.format(
-						"Couldn't start Tortoise Log because revisionRange is invalid. revisionStart=%s, revisionEnd=%s", //$NON-NLS-1$
-						revisionStart, revisionEnd));
-			}
-		}
-	}
-
-	/**
-	 * @param gitMergeUnit the {@link GITMergeUnit}
-	 */
-	private static void showGITChanges(final GITMergeUnit gitMergeUnit) {
-		throw new UnsupportedGITSupportException();
 	}
 
 	/**


### PR DESCRIPTION
## Type of request
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring 
- [ ] Documentation or documentation changes

## Related Issue(s)
#30

## Concept 
<!--- Why is this change required? What problem does it solve? -->
Use polymorphism to make the design cleaner and more flexible.
#### Description of the change
<!--- Describe your changes in detail -->
"[showChanges()](https://github.com/haghani-mehran/MergeProcessor/blob/68e518e5c86d620d2acfcf13cfc86dac916b6f0e/bundles/org.aposin.mergeprocessor/src/org/aposin/mergeprocessor/model/IMergeUnit.java#L116)" method is added to the [IMergeUnit](https://github.com/haghani-mehran/MergeProcessor/blob/68e518e5c86d620d2acfcf13cfc86dac916b6f0e/bundles/org.aposin.mergeprocessor/src/org/aposin/mergeprocessor/model/IMergeUnit.java#L24) interface as a default method, and default behavior for this method is `throw new UnsupportedVersionControlSystemSupportException();`.
[SVNMergeUnit](https://github.com/haghani-mehran/MergeProcessor/blob/68e518e5c86d620d2acfcf13cfc86dac916b6f0e/bundles/org.aposin.mergeprocessor/src/org/aposin/mergeprocessor/model/svn/SVNMergeUnit.java#L627) and [GitMergeUnit](https://github.com/haghani-mehran/MergeProcessor/blob/68e518e5c86d620d2acfcf13cfc86dac916b6f0e/bundles/org.aposin.mergeprocessor/src/org/aposin/mergeprocessor/model/git/GITMergeUnit.java#L321) has overridden the method to provide their own implementations.
#### Description of current state
In the showChanges method in the [MergeScriptDialog](https://github.com/aposin/MergeProcessor/blob/0f7f94cb472051d82566052ce9fe118a8ebf8883/bundles/org.aposin.mergeprocessor/src/org/aposin/mergeprocessor/view/mergeunit/MergeScriptDialog.java#L69) class, ["if" statements (type checking)](https://github.com/aposin/MergeProcessor/blob/0f7f94cb472051d82566052ce9fe118a8ebf8883/bundles/org.aposin.mergeprocessor/src/org/aposin/mergeprocessor/view/mergeunit/MergeScriptDialog.java#L297) are used to show changes for SVNMergeUnit and GitMergeUnit differently using [showSVNChanges](https://github.com/aposin/MergeProcessor/blob/0f7f94cb472051d82566052ce9fe118a8ebf8883/bundles/org.aposin.mergeprocessor/src/org/aposin/mergeprocessor/view/mergeunit/MergeScriptDialog.java#L310) and [showGITChanges](https://github.com/aposin/MergeProcessor/blob/0f7f94cb472051d82566052ce9fe118a8ebf8883/bundles/org.aposin.mergeprocessor/src/org/aposin/mergeprocessor/view/mergeunit/MergeScriptDialog.java#L335) methods.
#### Description of target state
By adding "showChanges()" method in the IMergeUnit interface and implement that in SVNMergeUnit and GitMergeUnit the code would become cleaner and more flexible by using polymorphism
#### Estimated investment / approximate investment
<!--- Full Time Equivalents / Lines of code / € costs or something like that -->
20 min.
#### Initiator
Mehran Khaksar Haghani

## Technical information
#### Platform / target area
#### known side-effects
#### other 
#### DB Changes (if so: incl. scripts with definitions and testdata)
#### How has this Tested?
#### Screenshots, Uploads, other documents (if appropriate):

## Checklist:
- [x] All the commits are signed.
- [x] My code follows the code style of this project.
- [x] I agree with die CLA.
- [x] I have read the CONTRIBUTING docs.
- [x] I have added/updated necessary documentation (if appropriate).
